### PR TITLE
Stop injecting Global Passwords, use Credential Bindings instead

### DIFF
--- a/seed-plugin/src/main/resources/branch-generation.groovy
+++ b/seed-plugin/src/main/resources/branch-generation.groovy
@@ -55,9 +55,6 @@ job("${BRANCH_FOLDER_PATH}/${BRANCH_SEED_NAME}") {
      * - downloads the dependencies
      * - extract the DSL bootstrap script from the indicated JAR
      */
-    wrappers {
-        injectPasswords()
-    }
     steps {
         shell '''\
 #!/bin/bash


### PR DESCRIPTION
Injection of Global Passwords is evil and no longer needed. Instead we can include Credentials Bindings in the config of the Generator jobs:
```
                    pipelineGenerationExtension '''
wrappers {
  credentialsBinding {
    usernamePassword('USER', 'PASSWORD', 'CREDENTIALID')
  }
}
'''
```
See documentation: https://github.com/jenkinsci/seed-plugin/wiki/Configuration